### PR TITLE
Fix negative time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ if (propertiesFile.exists()) {
 }
 
 group = 'tk.bteitalia.core'
-version = determineVersion('1.0.0')
+version = determineVersion('1.0.1')
 
 repositories {
     mavenCentral()

--- a/src/main/java/tk/bteitalia/core/feature/fixdh/FixDHListener.kt
+++ b/src/main/java/tk/bteitalia/core/feature/fixdh/FixDHListener.kt
@@ -7,6 +7,7 @@ import org.bukkit.event.player.PlayerJoinEvent
 import tk.bteitalia.core.BTEItalyCorePlugin
 import tk.bteitalia.core.config.FixDHConfig
 import tk.bteitalia.core.worldguard.WGRegionEnterEvent
+import kotlin.math.max
 
 internal class FixDHListener(
     private val corePlugin: BTEItalyCorePlugin,
@@ -14,7 +15,7 @@ internal class FixDHListener(
     private val config: FixDHConfig
 ) : Listener {
     private fun reloadDH() {
-        val ticksDelay = (config.delay * 20).toLong()
+        val ticksDelay = max(0, (config.delay * 20).toLong())
 
         corePlugin.server.scheduler.scheduleSyncDelayedTask(corePlugin, {
             val console = corePlugin.server.consoleSender


### PR DESCRIPTION
If the `duration` is negative in the config, the plugin will crash. This patch prevents it from happening.